### PR TITLE
fix: make-partitions start timestamp

### DIFF
--- a/bin/pgp-expire-partitions
+++ b/bin/pgp-expire-partitions
@@ -182,7 +182,7 @@ EOF
         echo "INFO: Expired partitions for ${table_schema}.${table_name}"
         printf "\n\nExpires partitions for  \`%s\`\n\n" "${table_schema}.${table_name}" >> /src/partition_maintenance.log
     else
-        echo "INFO: No expired partitions for ${table_schema}.${table_name}"
+        echo "INFO: No partitions expired for ${table_schema}.${table_name}"
         rm "${temp_migration_directory}/${output_filename}"
     fi
 

--- a/sql/15__make_partitions.sql
+++ b/sql/15__make_partitions.sql
@@ -210,7 +210,7 @@ BEGIN
     SELECT INTO v_start_timestamp
                 COALESCE(
                     (
-                        SELECT lower_bound
+                        SELECT upper_bound
                           FROM pgpartium.get_latest_partition(p_table_schema=>p_table_schema, p_table_name=>p_table_name)
                     )
                   , now()
@@ -219,7 +219,7 @@ BEGIN
     FOR v_partitions IN
         WITH dateset AS (
             SELECT "date"
-              FROM generate_series((date_trunc(substring(p_interval::text FROM '\d+\s*(\w+)'), v_start_timestamp) - (p_interval * p_past)), (now() + (p_interval * p_future)), p_interval) AS "date"
+              FROM generate_series((date_trunc(substring(p_interval::text FROM '\d+\s*(\w+)'), v_start_timestamp) - (p_interval * p_past)), (v_start_timestamp + (p_interval * p_future)), p_interval) AS "date"
         )
         SELECT replace(
                     replace(

--- a/tests/t/test_make_partitions.sql
+++ b/tests/t/test_make_partitions.sql
@@ -717,10 +717,6 @@ PREPARE expected_with_latest_partition_as_start_time AS VALUES (
 $$CREATE TABLE public.public__notifications__2025_02
     PARTITION OF public.notifications
     FOR VALUES FROM ('2025-02-01') TO ('2025-03-01');
-
-CREATE TABLE public.public__notifications__2025_03
-    PARTITION OF public.notifications
-    FOR VALUES FROM ('2025-03-01') TO ('2025-04-01');
 $$);
 
 SELECT results_eq(


### PR DESCRIPTION
make-partitions start timestamp was previously using lowerbound of the latest partition if there is one, this generate a range matching the latest partition but since we skip currently existing bounds, we were not making making another partition with the same bound as the latest partition. This PR fixes such range generation. In the same scope, we were using `now()` in the stop argument to `generate_series` when we are generating ranges, this is also wrong as we should be using the start timestamp (either the upper bound from the latest partition or `now()`).