### PR TITLE
fix: future is relative to the current timestamp

### DIFF
--- a/sql/15__make_partitions.sql
+++ b/sql/15__make_partitions.sql
@@ -219,7 +219,7 @@ BEGIN
     FOR v_partitions IN
         WITH dateset AS (
             SELECT "date"
-              FROM generate_series((date_trunc(substring(p_interval::text FROM '\d+\s*(\w+)'), v_start_timestamp) - (p_interval * p_past)), (v_start_timestamp + (p_interval * p_future)), p_interval) AS "date"
+              FROM generate_series((date_trunc(substring(p_interval::text FROM '\d+\s*(\w+)'), v_start_timestamp) - (p_interval * p_past)), (now() + (p_interval * p_future)), p_interval) AS "date"
         )
         SELECT replace(
                     replace(

--- a/tests/t/test_make_partitions.sql
+++ b/tests/t/test_make_partitions.sql
@@ -717,6 +717,10 @@ PREPARE expected_with_latest_partition_as_start_time AS VALUES (
 $$CREATE TABLE public.public__notifications__2025_02
     PARTITION OF public.notifications
     FOR VALUES FROM ('2025-02-01') TO ('2025-03-01');
+
+CREATE TABLE public.public__notifications__2025_03
+    PARTITION OF public.notifications
+    FOR VALUES FROM ('2025-03-01') TO ('2025-04-01');
 $$);
 
 SELECT results_eq(


### PR DESCRIPTION
While fixing the start timestamp for making partitions in https://github.com/bolajiwahab/pgpartium/pull/22, we introduced another bug by setting future as relative to start timestamp for generations. Future is relative to the current timestamp.