### PR TITLE
ci: keep pg_catalog before public

### DIFF
--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -62,5 +62,5 @@ pgp-setup-infrastructure
 
 # We need to include mock in our search_path
 echo "INFO: Adding mock to search_path"
-psql -v "ON_ERROR_STOP=1" --quiet --username=postgres --dbname=postgres -c "ALTER SYSTEM SET search_path = mock, public, pg_catalog;"
+psql -v "ON_ERROR_STOP=1" --quiet --username=postgres --dbname=postgres -c "ALTER SYSTEM SET search_path = mock, pg_catalog, public;"
 pg_ctlcluster "${pgversion}" pgpartium reload

--- a/tests/tap/test_expire_partitions.sql
+++ b/tests/tap/test_expire_partitions.sql
@@ -3,7 +3,7 @@ BEGIN;
 -- Deallocate all previous prepared statements.
 DEALLOCATE ALL;
 
-SET search_path TO mock, public, pg_catalog;
+SET search_path TO mock, pg_catalog, public;
 
 -- Plan the tests.
 SELECT plan(15);

--- a/tests/tap/test_make_partitions.sql
+++ b/tests/tap/test_make_partitions.sql
@@ -3,7 +3,7 @@ BEGIN;
 -- Deallocate all previous prepared statements.
 DEALLOCATE ALL;
 
-SET search_path TO mock, public, pg_catalog;
+SET search_path TO mock, pg_catalog, public;
 
 -- Plan the tests.
 SELECT plan(47);


### PR DESCRIPTION
## Pull Request Overview

This PR reorders the PostgreSQL search_path configuration to prioritize pg_catalog before public schema across test files and setup scripts. This ensures that built-in PostgreSQL system catalog functions and objects are resolved before any user-defined objects in the public schema.

- Reordered search_path from "mock, public, pg_catalog" to "mock, pg_catalog, public"
- Updated both test SQL files and the setup shell script consistently
- Maintains the mock schema as the highest priority while fixing the catalog/public ordering